### PR TITLE
UCJEPS-304: Adding four values to fieldLocState options

### DIFF
--- a/tomcat-main/src/main/resources/defaults/naturalhistory-collectionobject.xml
+++ b/tomcat-main/src/main/resources/defaults/naturalhistory-collectionobject.xml
@@ -932,6 +932,7 @@
 					<option id="Guizhou">Guizhou</option>
 					<option id="Ha Bach, Tinh">Ha Bach, Tinh</option>
 					<option id="Hainan">Hainan</option>
+                                        <option id="Halland">Halland</option>
 					<option id="Hamadan">Hamadan</option>
 					<option id="Heidelberg">Heidelberg</option>
 					<option id="Heredia">Heredia</option>
@@ -952,6 +953,7 @@
 					<option id="IN">IN</option>
 					<option id="Insular">Insular</option>
 					<option id="Ipiros">Ipiros</option>
+                                        <option id="Iqnique Province">Iqnique Province</option>
 					<option id="Iringa">Iringa</option>
 					<option id="Isabela">Isabela</option>
 					<option id="Izabel">Izabel</option>
@@ -965,6 +967,7 @@
 					<option id="KA">KA</option>
 					<option id="Kangean">Kangean</option>
 					<option id="Khorasan Province">Khorasan Province</option>
+                                        <option id="Kkanh Hoa">Kkanh Hoa</option>
 					<option id="KS">KS</option>
 					<option id="KwaZulu-Natal">KwaZulu-Natal</option>
 					<option id="KY">KY</option>
@@ -1144,6 +1147,7 @@
 					<option id="Tacna">Tacna</option>
 					<option id="TAM">TAM</option>
 					<option id="Tamaulipas">Tamaulipas</option>
+                                        <option id="Tarank Province">Tarank Province</option>
 					<option id="Tarija">Tarija</option>
 					<option id="Tarma">Tarma</option>
 					<option id="Tasmania">Tasmania</option>


### PR DESCRIPTION
These values were submitted by Margriet. I added four of the five she provided - the fifth, Victoria, already exists in the list of options. If Margriet can supply directions on how to disambiguate the two instances, we can make an additional change.

Ray, note that this branch is pulled from ucjeps_2.3 BEFORE UCJEPS-287 was merged in, so it does NOT have the county names added. Nor does it have my ucjeps-277 changes.

Thanks again.
