### PR TITLE
UCJEPS-274: Adding eight country names to fieldLocCountry options

### DIFF
--- a/tomcat-main/src/main/resources/defaults/naturalhistory-collectionobject.xml
+++ b/tomcat-main/src/main/resources/defaults/naturalhistory-collectionobject.xml
@@ -1210,6 +1210,7 @@
 					<option id="Argentina">Argentina</option>
 					<option id="Armenia">Armenia</option>
 					<option id="AUSTRALIA">AUSTRALIA</option>
+                                        <option id="Belgium">Belgium</option>
 					<option id="Belize">Belize</option>
 					<option id="Bermuda">Bermuda</option>
 					<option id="Bolivia">Bolivia</option>
@@ -1220,9 +1221,11 @@
 					<option id="Cameroon">Cameroon</option>
 					<option id="CANADA">CANADA</option>
 					<option id="Chile">Chile</option>
+                                        <option id="China">China</option>
 					<option id="Colombia">Colombia</option>
 					<option id="Cook Islands">Cook Islands</option>
 					<option id="Costa Rica">Costa Rica</option>
+                                        <option id="Croatia">Croatia</option>
 					<option id="Cuba">Cuba</option>
 					<option id="D R Congo">D R Congo</option>
 					<option id="DENMARK">DENMARK</option>
@@ -1244,6 +1247,7 @@
 					<option id="Haiti">Haiti</option>
 					<option id="Hispaniola">Hispaniola</option>
 					<option id="Honduras">Honduras</option>
+                                        <option id="Iceland">Iceland</option>
 					<option id="India">India</option>
 					<option id="Indonesia">Indonesia</option>
 					<option id="Iran">Iran</option>
@@ -1258,6 +1262,7 @@
 					<option id="Madagascar">Madagascar</option>
 					<option id="Malawi">Malawi</option>
 					<option id="Malaysia">Malaysia</option>
+                                        <option id="Marshall Islands">Marshall Islands</option>
 					<option id="MEXICO">MEXICO</option>
 					<option id="Micronesia">Micronesia</option>
 					<option id="Mongolia">Mongolia</option>
@@ -1266,6 +1271,7 @@
 					<option id="Namibia">Namibia</option>
 					<option id="Nepal">Nepal</option>
 					<option id="Netherlands Antilles">Netherlands Antilles</option>
+                                        <option id="Netherlands">Netherlands</option>
 					<option id="New Caledonia">New Caledonia</option>
 					<option id="New Zealand">New Zealand</option>
 					<option id="Nicaragua">Nicaragua</option>
@@ -1298,9 +1304,11 @@
 					<option id="Sri Lanka">Sri Lanka</option>
 					<option id="Sudan">Sudan</option>
 					<option id="Suriname">Suriname</option>
+                                        <option id="Sweden">Sweden</option>
 					<option id="Syria">Syria</option>
 					<option id="Taiwan">Taiwan</option>
 					<option id="Tanzania">Tanzania</option>
+                                        <option id="Thailand">Thailand</option>
 					<option id="Tonga">Tonga</option>
 					<option id="Trinidad and Tobago">Trinidad and Tobago</option>
 					<option id="Turkey">Turkey</option>


### PR DESCRIPTION
This branch was made from a clean ucjeps_2.3 branch before ucjeps_2.3 was updated to include work done for UCJEPS-287 and UCJEPS-304. In other words, only the additional fieldLocCountry option values appear here, not the additional fieldLocCounty and fieldLocState values added through those earlier pull requests.

Thanks Ray!
