### PR TITLE
CC-1049: Removed 'summary' value from 'mini' attribute of field 'taxo…

### DIFF
--- a/tomcat-main/src/main/resources/defaults/naturalhistory-collectionobject.xml
+++ b/tomcat-main/src/main/resources/defaults/naturalhistory-collectionobject.xml
@@ -108,7 +108,7 @@
 					</options>
 				</field>
 			</repeat>
-			<field id="taxonomicIdentHybridName" mini="summary,search,list,relate" section="naturalhistory"/>
+			<field id="taxonomicIdentHybridName" mini="search,list,relate" section="naturalhistory"/>
 			<field id="affinityTaxon" section="naturalhistory" autocomplete="taxon-taxon"/>
 			<field id="hybridFlag" section="naturalhistory" datatype="boolean"/>
 		</repeat>


### PR DESCRIPTION
Removed 'summary' value from 'mini' attribute of field 'taxonomicIdentHybridName'.  This was overriding the correct summary field of 'taxon'