### PR TITLE
PAHMA 8.0 Update

### DIFF
--- a/tomcat-main/src/main/resources/pahma-tenant.xml
+++ b/tomcat-main/src/main/resources/pahma-tenant.xml
@@ -25,6 +25,7 @@
 			<include src="base-procedure-osteology.xml,extensions/anthropology-procedure-osteology.xml" merge="xmlmerge.properties" />
 			<include src="base-procedure-exhibition.xml" />
 			<include src="base-procedure-groups.xml,pahma-procedure-groups.xml" merge="xmlmerge.properties" />
+			<include src="base-procedure-insurance.xml" />
 			<include src="base-procedure-intake.xml,pahma-procedure-intake.xml" merge="xmlmerge.properties" />
 			<include src="base-procedure-hit.xml,pahma-procedure-hit.xml" merge="xmlmerge.properties" />
 			<include src="base-procedure-loanin.xml,pahma-procedure-loanin.xml" merge="xmlmerge.properties" />
@@ -35,6 +36,7 @@
 			<include src="base-procedure-objectexit.xml,anthropology-procedure-objectexit.xml,pahma-procedure-objectexit.xml" merge="xmlmerge.properties" />
 			<include src="base-procedure-conservation.xml" />
 			<include src="base-procedure-uoc.xml" />
+			<include src="base-procedure-transport.xml" />
 
 			<include src="base-authority-contact.xml,anthropology-authority-contact.xml,pahma-authority-contact.xml" merge="xmlmerge.properties" />
 
@@ -51,6 +53,8 @@
 			<include src="base-authority-place.xml,anthropology-authority-place.xml,pahma-authority-place.xml,anthro-place.xml" merge="xmlmerge.properties" />
 			<include src="base-authority-taxon-termList.xml,pahma-authority-taxon-termList.xml" merge="xmlmerge.properties" />
 			<include src="base-authority-taxon.xml,pahma-authority-taxon.xml" merge="xmlmerge.properties" />
+			<include src="base-authority-chronology-termList.xml" />
+			<include src="base-authority-chronology.xml,pahma-authority-chronology.xml" merge="xmlmerge.properties" />
 			<include src="base-authority-concept-termList.xml,pahma-authority-concept-termList.xml" merge="xmlmerge.properties" />
 			<include src="base-authority-concept.xml,pahma-authority-concept.xml" merge="xmlmerge.properties" />
 			<include src="base-authority-work-termList.xml,pahma-authority-work-termList.xml" merge="xmlmerge.properties" />

--- a/tomcat-main/src/main/resources/tenants/pahma/base-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/pahma/base-instance-vocabularies.xml
@@ -2120,6 +2120,7 @@
 			<option id="inventory_count">inventory count</option>
 			<option id="associated_funerary_objects">associated funerary objects</option>
 			<option id="miniumum_num_of_individuals">minimum number of individuals</option>
+			<option id="piece_count">piece count</option>
 		</options>
 	</instance>
 	<instance id="vocab-assocauthorityrelationtype">

--- a/tomcat-main/src/main/resources/tenants/pahma/pahma-authority-chronology.xml
+++ b/tomcat-main/src/main/resources/tenants/pahma/pahma-authority-chronology.xml
@@ -1,0 +1,19 @@
+<record id="chronology" type="authority">
+  <instances id="chronology">
+    <instance id="chronology-era">
+      <web-url>era</web-url>
+      <title-ref>era</title-ref>
+      <title>Era Chronologies</title>
+    </instance>
+    <instance id="chronology-event">
+      <web-url>event</web-url>
+      <title-ref>event</title-ref>
+      <title>Event Chronologies</title>
+    </instance>
+    <instance id="chronology-field_collection">
+      <web-url>field_collection</web-url>
+      <title-ref>field_collection</title-ref>
+      <title>Field Collection Chronologies</title>
+    </instance>
+  </instances>
+</record>


### PR DESCRIPTION
This updates UCB 8.0 application to resolve issues found in QA:
- The Insurance, Transport, and Chronology record types have been added to PAHMA
- The Field Collection Chronology vocabulary has been added to the Chronology authority
- "piece count" has been added to the default values of the `objectcounttypes` term list