### PR TITLE
DRYD-1895: added phenological observation group of fields and vocabularies

### DIFF
--- a/tomcat-main/src/main/resources/tenants/ucbg/botgarden-collectionobject.xml
+++ b/tomcat-main/src/main/resources/tenants/ucbg/botgarden-collectionobject.xml
@@ -198,6 +198,15 @@
 		<field id="researchUse" datatype="boolean" section="botgarden"/>
 		<field id="ignoreRedDot" datatype="boolean" section="botgarden"/>
 		<field id="fragrance" datatype="boolean" section="botgarden"/>
+
+		<repeat id="phenologicalObservationGroupList/phenologicalObservationGroup" section="botgarden">
+			<field id="observationDate" datatype="date" section="botgarden"/>
+			<field id="observationPhenophase" section="botgarden" ui-type="enum" autocomplete="vocab-observationphenophase"/>
+			<field id="observationQuantity" section="botgarden" ui-type="enum" autocomplete="vocab-observationquantity"/>
+			<field id="observationBy" section="botgarden" autocomplete="person-person"/>
+			<field id="observationNote" section="botgarden"/>
+		</repeat>
+
 		<field id="flowersJan" section="botgarden">
 			<options>
 				<option id="No" default="yes">No</option>

--- a/tomcat-main/src/main/resources/tenants/ucbg/domain-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/ucbg/domain-instance-vocabularies.xml
@@ -1400,4 +1400,26 @@
 			<option id="usetype02" from-static-id="other">Other</option>
 		</options>
 	</instance>
+	<instance id="vocab-observationphenophase">
+		<web-url>observationphenophase</web-url>
+		<title-ref>observationphenophase</title-ref>
+		<title>Phenological Observation Phenophase</title>
+		<options>
+			<option id="flowers">Flowers</option>
+			<option id="fruits">Fruits</option>
+			<option id="flowersFruits">Flowers/Fruits</option>
+			<option id="cones">Cones</option>
+			<option id="sporesSporangia">Spores/Sporangia</option>
+			<option id="vegetative">Vegetative</option>
+		</options>
+	</instance>
+	<instance id="vocab-observationquantity">
+		<web-url>observationquantity</web-url>
+		<title-ref>observationquantity</title-ref>
+		<title>Phenological Observation Quantity</title>
+		<options>
+			<option id="some">Some</option>
+			<option id="many">Many</option>
+		</options>
+	</instance>
 </root>


### PR DESCRIPTION
**What does this do?**
The updates include:
* adding `phenologicalObservationGroup` repeating group of fields to the botgarden collection object
* adding `observationphenophase` and `observationquantity` vocabs

**Why are we doing this? (with JIRA link)**
We need to replace the existing fruit and flower monthly block of fields with a repeating block of fields that hold broader phenological observations: 
https://collectionspace.atlassian.net/browse/DRYD-1895
https://collectionspace.atlassian.net/browse/DRYD-1896
https://collectionspace.atlassian.net/browse/DRYD-1897

**How should this be tested? Do these changes have associated tests?**
Please follow the test guidelines in: 
https://github.com/cspace-deployment/cspace-ui-plugin-profile-ucbg.js/pull/81

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@spirosdi tested locally.