### PR TITLE
DRYD-1898: Procedure > Bot Garden > Modify Current Location

### DIFF
--- a/tomcat-main/src/main/resources/tenants/ucbg/botgarden-procedure-movement.xml
+++ b/tomcat-main/src/main/resources/tenants/ucbg/botgarden-procedure-movement.xml
@@ -27,7 +27,7 @@
 		<field id="decimalLongitude" datatype="float" section="botgarden"/>
 		<field id="geodeticDatum" section="botgarden" ui-type="enum"/>
 		<field id="coordUncertaintyInMeters" datatype="integer" section="botgarden"/>
-		<field id="pointRadiusSpatialFit" section="botgarden"/>
+		<field id="pointRadiusSpatialFit" datatype="integer" section="botgarden"/>
 		<field id="geoReferencedBy" section="botgarden" autocomplete="true"/>
 		<field id="geoRefDate" datatype="date" section="botgarden"/>
 		<field id="geoRefProtocol" section="botgarden" ui-type="enum" autocomplete="vocab-geoRefProtocol"/>

--- a/tomcat-main/src/main/resources/tenants/ucbg/botgarden-procedure-movement.xml
+++ b/tomcat-main/src/main/resources/tenants/ucbg/botgarden-procedure-movement.xml
@@ -25,14 +25,14 @@
 	<section id="geoReferenceInformation">
 		<field id="decimalLatitude" datatype="float" section="botgarden"/>
 		<field id="decimalLongitude" datatype="float" section="botgarden"/>
-		<field id="geodeticDatum" section="botgarden" ui-type="enum"/>
+		<field id="geodeticDatum" section="botgarden"/>
 		<field id="coordUncertaintyInMeters" datatype="integer" section="botgarden"/>
 		<field id="pointRadiusSpatialFit" datatype="integer" section="botgarden"/>
 		<field id="geoReferencedBy" section="botgarden" autocomplete="true"/>
 		<field id="geoRefDate" datatype="date" section="botgarden"/>
-		<field id="geoRefProtocol" section="botgarden" ui-type="enum" autocomplete="vocab-geoRefProtocol"/>
-		<field id="geoRefSource" section="botgarden" ui-type="enum" autocomplete="vocab-geoRefSource"/>
-		<field id="geoRefVerificationStatus" section="botgarden" ui-type="enum" autocomplete="vocab-geoRefVerificationStatus"/>
+		<field id="geoRefProtocol" section="botgarden" ui-type="enum" autocomplete="true"/>
+		<field id="geoRefSource" section="botgarden" ui-type="enum" autocomplete="true"/>
+		<field id="geoRefVerificationStatus" section="botgarden" ui-type="enum" autocomplete="true"/>
 		<field id="geoRefRemarks" section="botgarden"/>
 		<field id="geoRefPlaceName" section="botgarden"/>
 	</section>

--- a/tomcat-main/src/main/resources/tenants/ucbg/botgarden-procedure-movement.xml
+++ b/tomcat-main/src/main/resources/tenants/ucbg/botgarden-procedure-movement.xml
@@ -22,6 +22,21 @@
 
 	<!-- Local fields -->
 
+	<section id="geoReferenceInformation">
+		<field id="decimalLatitude" datatype="float" section="botgarden"/>
+		<field id="decimalLongitude" datatype="float" section="botgarden"/>
+		<field id="geodeticDatum" section="botgarden" ui-type="enum"/>
+		<field id="coordUncertaintyInMeters" datatype="integer" section="botgarden"/>
+		<field id="pointRadiusSpatialFit" section="botgarden"/>
+		<field id="geoReferencedBy" section="botgarden" autocomplete="true"/>
+		<field id="geoRefDate" datatype="date" section="botgarden"/>
+		<field id="geoRefProtocol" section="botgarden" ui-type="enum" autocomplete="vocab-geoRefProtocol"/>
+		<field id="geoRefSource" section="botgarden" ui-type="enum" autocomplete="vocab-geoRefSource"/>
+		<field id="geoRefVerificationStatus" section="botgarden" ui-type="enum" autocomplete="vocab-geoRefVerificationStatus"/>
+		<field id="geoRefRemarks" section="botgarden"/>
+		<field id="geoRefPlaceName" section="botgarden"/>
+	</section>
+
 	<section id="labelInformation">
 		<field id="labelRequested" ui-search="repeatable" section="botgarden">
 			<options>

--- a/tomcat-main/src/main/resources/tenants/ucbg/domain-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/ucbg/domain-instance-vocabularies.xml
@@ -1311,10 +1311,10 @@
 		<title-ref>geoRefProtocol</title-ref>
 		<title>Georeference Protocol</title>
 		<options>
-			<option id="chapmanWieczorek2006GuideBestPracticesGeoreferencing">Chapman, Wieczorek 2006, Guide to Best Practices for Georeferencing</option>
-			<option id="manisHerpnetOrnisGeoreferencingGuidelines">MaNIS/HerpNet/ORNIS Georeferencing Guidelines</option>
-			<option id="georeferencingDummies">Georeferencing For Dummies</option>
-			<option id="biogeomancer">BioGeomancer</option>
+			<option id="geoRefProtocol00">Chapman, Wieczorek 2006, Guide to Best Practices for Georeferencing</option>
+			<option id="geoRefProtocol01">MaNIS/HerpNet/ORNIS Georeferencing Guidelines</option>
+			<option id="geoRefProtocol02">Georeferencing For Dummies</option>
+			<option id="geoRefProtocol03">BioGeomancer</option>
 		</options>
 	</instance>
 	<instance id="vocab-geoRefSource">

--- a/tomcat-main/src/main/resources/tenants/ucbg/domain-instance-vocabularies.xml
+++ b/tomcat-main/src/main/resources/tenants/ucbg/domain-instance-vocabularies.xml
@@ -1301,6 +1301,40 @@
 			<option id="actCode04">Theft</option>
 			<option id="actCode05">Other</option>
 			<option id="actCode06">Revived</option>
+			<option id="actCode07">Georeferenced</option>
+			<option id="actCode08">Moved and Georeferenced</option>
+			<option id="actCode09">Planted Out and Georeferenced</option>
+		</options>
+	</instance>
+	<instance id="vocab-geoRefProtocol">
+		<web-url>geoRefProtocol</web-url>
+		<title-ref>geoRefProtocol</title-ref>
+		<title>Georeference Protocol</title>
+		<options>
+			<option id="chapmanWieczorek2006GuideBestPracticesGeoreferencing">Chapman, Wieczorek 2006, Guide to Best Practices for Georeferencing</option>
+			<option id="manisHerpnetOrnisGeoreferencingGuidelines">MaNIS/HerpNet/ORNIS Georeferencing Guidelines</option>
+			<option id="georeferencingDummies">Georeferencing For Dummies</option>
+			<option id="biogeomancer">BioGeomancer</option>
+		</options>
+	</instance>
+	<instance id="vocab-geoRefSource">
+		<web-url>geoRefSource</web-url>
+		<title-ref>geoRefSource</title-ref>
+		<title>Georeference Source</title>
+		<options>
+			<option id="berkeleyMapper">BerkeleyMapper</option>
+			<option id="iphone14">iPhone 14</option>
+			<option id="trimble">Trimble</option>
+		</options>
+	</instance>
+	<instance id="vocab-geoRefVerificationStatus">
+		<web-url>geoRefVerificationStatus</web-url>
+		<title-ref>geoRefVerificationStatus</title-ref>
+		<title>Georeference Verification</title>
+		<options>
+			<option id="unverified">unverified</option>
+			<option id="verifiedDataCustodian">verified by data custodian</option>
+			<option id="verifiedContributor">verified by contributor</option>
 		</options>
 	</instance>
 	<instance id="vocab-scarStrat">


### PR DESCRIPTION
**What does this do?**
* Added `geoReferenceInformation` section containing the new fields to the `botgarden-procedure-movement`
* Added new `actionCodes`
* Added new term lists

**Why are we doing this? (with JIRA link)**
Enabling tracking lat/long information at the current location procedure level: https://collectionspace.atlassian.net/browse/DRYD-1898

**How should this be tested? Do these changes have associated tests?**
Please follow the instructions at the:
https://github.com/cspace-deployment/cspace-ui-plugin-profile-ucbg.js/pull/85

**Dependencies for merging? Releasing to production?**
It should be merged and releases along these PRs:
https://github.com/cspace-deployment/services/pull/450
https://github.com/cspace-deployment/cspace-ui-plugin-profile-ucbg.js/pull/85

**Has the application documentation been updated for these changes?**
N/A

**Did someone actually run this code to verify it works?**
@spirosdi ran this locally

**Have any new accessibility violations been handled?**
N/A
